### PR TITLE
feat: mark repository_secrets as sensitive

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -133,11 +133,11 @@ resource "github_repository_webhook" "webhook" {
 
 # Repository secrets
 resource "github_actions_secret" "repo_secret" {
-  for_each = var.repository_secrets != null ? var.repository_secrets : {}
+  for_each = nonsensitive(toset(keys(var.repository_secrets != null ? var.repository_secrets : {})))
 
   repository      = github_repository.this.name
   secret_name     = each.key
-  plaintext_value = each.value
+  plaintext_value = var.repository_secrets[each.key]
 }
 
 # Repository variables

--- a/modules/repository/variables.tf
+++ b/modules/repository/variables.tf
@@ -247,6 +247,7 @@ variable "repository_secrets" {
   description = "Map of secrets at the REPOSITORY level (global). Keys are secret names, values are secret values."
   type        = map(string)
   default     = {}
+  sensitive   = true
 }
 
 variable "repository_variables" {


### PR DESCRIPTION
## Summary

Adds `sensitive = true` to the `repository_secrets` variable in the repository submodule, implementing defense-in-depth for secret values.

## Changes

### `repository_secrets` variable marked as sensitive
- Secret values are now hidden from `terraform plan` and `terraform apply` output
- Uses `nonsensitive(toset(keys(...)))` for `for_each` iteration — only secret **names** are visible in plan, **values** remain hidden
- The GitHub provider already marks `plaintext_value` as sensitive in `github_actions_secret`, but this adds an extra layer at the Terraform variable level

### What was NOT marked sensitive (and why)
- **`environments`**: Contains mixed sensitive (secrets) and non-sensitive (approvers, variables, env names) data. Marking the whole variable sensitive would break `for_each` and hide useful plan output. The provider already handles `plaintext_value` sensitivity on `github_actions_environment_secret`.
- **`webhooks`**: Only the optional `secret` field is sensitive. The provider already handles that attribute. Marking the whole map would break `for_each`.
- **`deploy_keys`**: Contains SSH **public** keys (not private), so not sensitive.

## Validation
- `terraform fmt -recursive` ✅
- `terraform validate` ✅
- `terraform test` — 19/19 governance + 5/5 submodule ✅
- Pre-commit hooks all pass ✅